### PR TITLE
differentiate skippable exception and non-skippable exception

### DIFF
--- a/eval_protocol/mcp/execution/manager.py
+++ b/eval_protocol/mcp/execution/manager.py
@@ -12,17 +12,16 @@ import os
 import threading
 import time
 from dataclasses import asdict
-from typing import TYPE_CHECKING, Any, AsyncIterator, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 import anyio
-import httpx
 from openai.types import CompletionUsage
 
 from vendor.tau2.data_model.message import AssistantMessage, UserMessage
 from vendor.tau2.user.user_simulator import UserSimulator
 
 from ...models import EvaluationRow, InputMetadata, Message
-from ...types import MCPSession, MCPToolCall, TerminationReason, Trajectory
+from ...types import TerminationReason, Trajectory, RolloutTerminationException
 
 if TYPE_CHECKING:
     from ..session.manager import GeneralMCPVectorEnv
@@ -107,7 +106,7 @@ class ExecutionManager:
                 )
 
                 # Convert trajectory to EvaluationRow immediately
-                evaluation_row = evaluation_rows[idx]
+                evaluation_row: EvaluationRow = evaluation_rows[idx]
 
                 # Handle multimodal content by extracting text from complex content structures
                 messages = []
@@ -137,14 +136,16 @@ class ExecutionManager:
                 }
 
                 if trajectory.terminated:
+                    evaluation_row.rollout_status.termination_reason = trajectory.termination_reason
+                    # preserve the true error mesage if there are any
+                    if trajectory.control_plane_summary.get("error_message"):
+                        evaluation_row.rollout_status.extra_info = {
+                            "error_message": trajectory.control_plane_summary.get("error_message")
+                        }
                     if trajectory.termination_reason == TerminationReason.ERROR:
                         evaluation_row.rollout_status.status = "error"
-                        evaluation_row.rollout_status.termination_reason = trajectory.control_plane_summary.get(
-                            "error_message", None
-                        )
                     else:
                         evaluation_row.rollout_status.status = "finished"
-                        evaluation_row.rollout_status.termination_reason = trajectory.termination_reason
                 else:
                     evaluation_row.rollout_status.status = "running"
 
@@ -437,14 +438,13 @@ class ExecutionManager:
             logger.info(
                 f"✅ Rollout {rollout_idx} completed: {trajectory.steps} steps, reward: {trajectory.total_reward:.2f}, termination: {trajectory.termination_reason}, in thread {threading.current_thread().name}"
             )
-
-        except asyncio.CancelledError:
+        except RolloutTerminationException as e:
+            trajectory.terminated = True
+            trajectory.termination_reason = TerminationReason.INTERRUPTED
+            trajectory.control_plane_summary.update({"error_message": str(e)})
+            logger.error(f"🚨 Rollout {rollout_idx} terminated due to user exception: {str(e)}", exc_info=True)
+        except asyncio.CancelledError:  # need explicit catch since it doesn't inherit from Exception
             failure_reason = "asyncio context cancelled"
-            logger.error(
-                f"🚨 Error in rollout {session.dataset_row.id} {rollout_idx}: {failure_reason}", exc_info=True
-            )
-        except (anyio.ClosedResourceError, anyio.BrokenResourceError):
-            failure_reason = "anyioconnection/resource error"
             logger.error(
                 f"🚨 Error in rollout {session.dataset_row.id} {rollout_idx}: {failure_reason}", exc_info=True
             )
@@ -461,7 +461,6 @@ class ExecutionManager:
                 await envs.connection_manager.reset_session(session)
             except Exception as e:
                 logger.warning(f"Failed to reset session {session.session_id}: {type(e).__name__}: {e}", exc_info=True)
-
             try:
                 await envs.connection_manager.close_session(session)
             except Exception as e:

--- a/eval_protocol/models.py
+++ b/eval_protocol/models.py
@@ -1,5 +1,6 @@
 import os
 from datetime import datetime
+from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, TypedDict, Union
 
 from openai.types import CompletionUsage
@@ -289,7 +290,13 @@ class RolloutStatus(BaseModel):
     finished: Rollout finished.
     error: Rollout failed due to unexpected error. The rollout record should be discard.
     """
-    status: Literal["running", "finished", "error"] = Field("running", description="Status of the rollout.")
+
+    class Status(str, Enum):
+        RUNNING = "running"
+        FINISHED = "finished"
+        ERROR = "error"
+
+    status: Status = Field(Status.RUNNING, description="Status of the rollout.")
     termination_reason: Optional[TerminationReason] = Field(
         None, description="reason of the rollout status, mapped to values in TerminationReason"
     )

--- a/eval_protocol/models.py
+++ b/eval_protocol/models.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from eval_protocol.get_pep440_version import get_pep440_version
 from eval_protocol.human_id import generate_id
+from eval_protocol.types import TerminationReason
 
 
 class ChatCompletionContentPartTextParam(BaseModel):
@@ -285,14 +286,14 @@ class RolloutStatus(BaseModel):
 
     """
     running: Unfinished rollout which is still in progress.
-    finished: Rollout finished successfully.
-    error: Rollout failed.
-    stopped: Rollout terminated unexpectedly (e.g. max step, control plane signal, user stop).
+    finished: Rollout finished.
+    error: Rollout failed due to unexpected error. The rollout record should be discard.
     """
     status: Literal["running", "finished", "error"] = Field("running", description="Status of the rollout.")
-    termination_reason: Optional[str] = Field(
-        "", description="reason of the rollout status, mapped to values in TerminationReason"
+    termination_reason: Optional[TerminationReason] = Field(
+        None, description="reason of the rollout status, mapped to values in TerminationReason"
     )
+    extra_info: Optional[Dict[str, Any]] = Field(None, description="Extra information about the rollout status.")
 
 
 class EvaluationRow(BaseModel):

--- a/eval_protocol/pytest/utils.py
+++ b/eval_protocol/pytest/utils.py
@@ -257,9 +257,9 @@ async def rollout_processor_with_retry(
             current_attempts = retry_counts.get(rollout_id, 0)
 
             if current_attempts >= max_retry:
-                assert (
-                    failed_row.rollout_status and failed_row.rollout_status.status == RolloutStatus.Status.ERROR
-                ), f"Rollout {failed_row.execution_metadata.rollout_id} did not fail with error status"
+                assert failed_row.rollout_status and failed_row.rollout_status.status == RolloutStatus.Status.ERROR, (
+                    f"Rollout {failed_row.execution_metadata.rollout_id} did not fail with error status"
+                )
                 failed_permanently.append(failed_row)
                 await queue.put(failed_row)  # put failed row on queue
                 return

--- a/eval_protocol/types/__init__.py
+++ b/eval_protocol/types/__init__.py
@@ -1,4 +1,4 @@
 from .types import DatasetRow, MCPSession, MCPToolCall, TerminationReason, Trajectory
-from .errors import RolloutTerminationException
+from .errors import NonSkippableException
 
-__all__ = ["MCPSession", "MCPToolCall", "TerminationReason", "Trajectory", "DatasetRow", "RolloutTerminationException"]
+__all__ = ["MCPSession", "MCPToolCall", "TerminationReason", "Trajectory", "DatasetRow", "NonSkippableException"]

--- a/eval_protocol/types/__init__.py
+++ b/eval_protocol/types/__init__.py
@@ -1,3 +1,4 @@
 from .types import DatasetRow, MCPSession, MCPToolCall, TerminationReason, Trajectory
+from .errors import RolloutTerminationException
 
-__all__ = ["MCPSession", "MCPToolCall", "TerminationReason", "Trajectory", "DatasetRow"]
+__all__ = ["MCPSession", "MCPToolCall", "TerminationReason", "Trajectory", "DatasetRow", "RolloutTerminationException"]

--- a/eval_protocol/types/errors.py
+++ b/eval_protocol/types/errors.py
@@ -1,13 +1,11 @@
-class RolloutTerminationException(Exception):
+class NonSkippableException(Exception):
     """
-    Exception raised during rollout. This error means the rollout needs to be terminated and its not retriable,
-    and the trajectory need to be perserved for future evalution or analysis.
+    A type of custom exception raised during rollout or evaluation. This error means the rollout/evaluation result is not skippable and need to be
+    processed explicitly.
 
     For example, if the policy (llm) returns 400 User error, we need to end the rollout but keep the trajectory.
     It differs from other exceptions such as network error, which are retriable and the trajectory should be discarded if
     it fails eventually after retries.
-
-    This will cause trajectory.termination_reason to be set to TerminationReason.INTERRUPTED.
     """
 
     pass

--- a/eval_protocol/types/errors.py
+++ b/eval_protocol/types/errors.py
@@ -1,0 +1,13 @@
+class RolloutTerminationException(Exception):
+    """
+    Exception raised during rollout. This error means the rollout needs to be terminated and its not retriable,
+    and the trajectory need to be perserved for future evalution or analysis.
+
+    For example, if the policy (llm) returns 400 User error, we need to end the rollout but keep the trajectory.
+    It differs from other exceptions such as network error, which are retriable and the trajectory should be discarded if
+    it fails eventually after retries.
+
+    This will cause trajectory.termination_reason to be set to TerminationReason.INTERRUPTED.
+    """
+
+    pass

--- a/eval_protocol/types/types.py
+++ b/eval_protocol/types/types.py
@@ -13,6 +13,7 @@ class TerminationReason(str, Enum):
     CONTROL_PLANE_SIGNAL: Trajectory ends because the control plane signals termination (e.g. env goal reached or failure condition)
     USER_STOP: Trajectory ends because the simulated user signals to stop
     ERROR: Trajectory ends because of an error
+    INTERRUPTED: Trajectory is interrupted by some non-system related reason (e.g. policy returns unexpected response and we need to terminate the rollout).
     STOP: Trajectory ends by the policy (mapped to llm response stop reason "stop")
     LENGTH: Trajectory ends by the policy (mapped to llm response stop reason "length")
     TOOL_CALLS: Trajectory ends by the policy with a hanging tool call response (mapped to llm response stop reason "tool_calls")
@@ -22,6 +23,7 @@ class TerminationReason(str, Enum):
     CONTROL_PLANE_SIGNAL = "control_plane_signal"
     USER_STOP = "user_stop"
     ERROR = "error"
+    INTERRUPTED = "interrupted"
     STOP = "stop"
     LENGTH = "length"
     TOOL_CALLS = "tool_calls"

--- a/eval_protocol/types/types.py
+++ b/eval_protocol/types/types.py
@@ -12,8 +12,8 @@ class TerminationReason(str, Enum):
     MAX_STEPS: Trajectory ends because we hit the step limit
     CONTROL_PLANE_SIGNAL: Trajectory ends because the control plane signals termination (e.g. env goal reached or failure condition)
     USER_STOP: Trajectory ends because the simulated user signals to stop
-    ERROR: Trajectory ends because of an error
-    INTERRUPTED: Trajectory is interrupted by some non-system related reason (e.g. policy returns unexpected response and we need to terminate the rollout).
+    SKIPPABLE_ERROR: Trajectory ends because of an error, this trajectory can be discarded/skipped during postprocessing/evaluation.
+    NON_SKIPPABLE_ERROR: Trajectory is interrupted due to some non-skippable error (e.g. policy returns unexpected response and we need to terminate the rollout).
     STOP: Trajectory ends by the policy (mapped to llm response stop reason "stop")
     LENGTH: Trajectory ends by the policy (mapped to llm response stop reason "length")
     TOOL_CALLS: Trajectory ends by the policy with a hanging tool call response (mapped to llm response stop reason "tool_calls")
@@ -22,8 +22,8 @@ class TerminationReason(str, Enum):
     MAX_STEPS = "max_steps"
     CONTROL_PLANE_SIGNAL = "control_plane_signal"
     USER_STOP = "user_stop"
-    ERROR = "error"
-    INTERRUPTED = "interrupted"
+    SKIPPABLE_ERROR = "skippable_error"
+    NON_SKIPPABLE_ERROR = "non_skippable_error"
     STOP = "stop"
     LENGTH = "length"
     TOOL_CALLS = "tool_calls"
@@ -40,8 +40,10 @@ class TerminationReason(str, Enum):
             return cls.CONTROL_PLANE_SIGNAL
         elif value == "user_stop":
             return cls.USER_STOP
-        elif value == "error":
-            return cls.ERROR
+        elif value == "skippable_error":
+            return cls.SKIPPABLE_ERROR
+        elif value == "non_skippable_error":
+            return cls.NON_SKIPPABLE_ERROR
         elif value == "tool_calls":
             return cls.TOOL_CALLS
         else:


### PR DESCRIPTION
~~Introducing a new custom Exception type: RolloutTerminationException, which means the rollout should be interrupted but the trajectory should be kept for future evaluation or analysis, unlike the system retryable errors such as network error or timeout.~~


~~For error messages, we pass it from control_plane_summary and then preserve them into the rollout_status.extra_info, and align the rollout_status.termination_reason with the TerninationReason enum.~~

~~In practice, we should expect custom Policy implementation can throw RolloutTerminationException to terminate the rollout, while keeping the rollout_status.status as "finished" to make sure poeople wont filter these results when doing post processing or evaluation~~


## Differentiate SKIPPABLE_ERROR & NON_SKIPPABLE_ERROR in rollout

- Introduce new custom exception type **NonSkippableException**, and updated termination_reason with "SKIPPABLE_ERROR" and "NON_SKIPPABLE_ERROR". Skippable errors are typically retry-able and can be skipped in following operations (such as evaluation, post analysis or training), while Non-skippable errors need to be explicitly handled by the user later. During rollout, NonSkippableException will cause NON_SKIPPABLE_ERROR, and it will keep the trajectory history so far. 
- Multiturn rollout execution manager (mcp/execution/manager.py) will only try catch on NonSkippableException, and will mark the `rollout_status.status` as `finished` while marking the `rollout_status.termination_reason`  as NON_SKIPPABLE_ERROR. The rest exceptions will be raised to upper layers, and will be handled inside rollout_processors.



