### PR TITLE
Add "weight" to "Message" and helper func to dump model for chat completion request

### DIFF
--- a/eval_protocol/models.py
+++ b/eval_protocol/models.py
@@ -256,7 +256,6 @@ class ChatCompletionContentPartTextParam(BaseModel):
 
 class Message(BaseModel):
     """Chat message model with trajectory evaluation support."""
-
     role: str  # assistant, user, system, tool
     content: Optional[Union[str, List[ChatCompletionContentPartTextParam]]] = Field(
         default="", description="The content of the message."
@@ -269,7 +268,12 @@ class Message(BaseModel):
     tool_calls: Optional[List[ChatCompletionMessageToolCall]] = None
     function_call: Optional[FunctionCall] = None
     control_plane_step: Optional[Dict[str, Any]] = None
+    weight: Optional[int] = None
 
+    def dump_mdoel_for_chat_completion_request(self):
+        """Only keep chat completion accepted fields"""
+        return self.model_dump(exclude_none=True, exclude={"control_plane_step", "weight", "reasoning_content"})
+        
     @classmethod
     def model_validate(cls, obj, *args, **kwargs):
         if isinstance(obj, dict):

--- a/eval_protocol/models.py
+++ b/eval_protocol/models.py
@@ -256,6 +256,7 @@ class ChatCompletionContentPartTextParam(BaseModel):
 
 class Message(BaseModel):
     """Chat message model with trajectory evaluation support."""
+
     role: str  # assistant, user, system, tool
     content: Optional[Union[str, List[ChatCompletionContentPartTextParam]]] = Field(
         default="", description="The content of the message."
@@ -273,7 +274,7 @@ class Message(BaseModel):
     def dump_mdoel_for_chat_completion_request(self):
         """Only keep chat completion accepted fields"""
         return self.model_dump(exclude_none=True, exclude={"control_plane_step", "weight", "reasoning_content"})
-        
+
     @classmethod
     def model_validate(cls, obj, *args, **kwargs):
         if isinstance(obj, dict):

--- a/eval_protocol/models.py
+++ b/eval_protocol/models.py
@@ -1,7 +1,6 @@
 import os
 from datetime import datetime
 from enum import Enum
-from re import A
 from typing import Any, ClassVar, Dict, List, Literal, Optional, TypedDict, Union
 
 JSONType = Union[Dict[str, Any], List[Any], str, int, float, bool, None]

--- a/eval_protocol/models.py
+++ b/eval_protocol/models.py
@@ -1,6 +1,7 @@
 import os
 from datetime import datetime
 from enum import Enum
+from re import A
 from typing import Any, ClassVar, Dict, List, Literal, Optional, TypedDict, Union
 
 JSONType = Union[Dict[str, Any], List[Any], str, int, float, bool, None]
@@ -256,7 +257,8 @@ class ChatCompletionContentPartTextParam(BaseModel):
 
 class Message(BaseModel):
     """Chat message model with trajectory evaluation support."""
-
+    
+    model_config = ConfigDict(extra="allow")
     role: str  # assistant, user, system, tool
     content: Optional[Union[str, List[ChatCompletionContentPartTextParam]]] = Field(
         default="", description="The content of the message."
@@ -269,11 +271,10 @@ class Message(BaseModel):
     tool_calls: Optional[List[ChatCompletionMessageToolCall]] = None
     function_call: Optional[FunctionCall] = None
     control_plane_step: Optional[Dict[str, Any]] = None
-    weight: Optional[int] = None
-
     def dump_mdoel_for_chat_completion_request(self):
         """Only keep chat completion accepted fields"""
-        return self.model_dump(exclude_none=True, exclude={"control_plane_step", "weight", "reasoning_content"})
+        exclude_fields = {"control_plane_step", "reasoning_content"} | set(self.model_extra.keys()) if self.model_extra else set()
+        return self.model_dump(exclude_none=True, exclude=exclude_fields)
 
     @classmethod
     def model_validate(cls, obj, *args, **kwargs):

--- a/eval_protocol/models.py
+++ b/eval_protocol/models.py
@@ -257,7 +257,7 @@ class ChatCompletionContentPartTextParam(BaseModel):
 
 class Message(BaseModel):
     """Chat message model with trajectory evaluation support."""
-    
+
     model_config = ConfigDict(extra="allow")
     role: str  # assistant, user, system, tool
     content: Optional[Union[str, List[ChatCompletionContentPartTextParam]]] = Field(
@@ -271,9 +271,12 @@ class Message(BaseModel):
     tool_calls: Optional[List[ChatCompletionMessageToolCall]] = None
     function_call: Optional[FunctionCall] = None
     control_plane_step: Optional[Dict[str, Any]] = None
+
     def dump_mdoel_for_chat_completion_request(self):
         """Only keep chat completion accepted fields"""
-        exclude_fields = {"control_plane_step", "reasoning_content"} | set(self.model_extra.keys()) if self.model_extra else set()
+        exclude_fields = (
+            {"control_plane_step", "reasoning_content"} | set(self.model_extra.keys()) if self.model_extra else set()
+        )
         return self.model_dump(exclude_none=True, exclude=exclude_fields)
 
     @classmethod

--- a/eval_protocol/models.py
+++ b/eval_protocol/models.py
@@ -258,7 +258,6 @@ class ChatCompletionContentPartTextParam(BaseModel):
 class Message(BaseModel):
     """Chat message model with trajectory evaluation support."""
 
-    model_config = ConfigDict(extra="allow")
     role: str  # assistant, user, system, tool
     content: Optional[Union[str, List[ChatCompletionContentPartTextParam]]] = Field(
         default="", description="The content of the message."
@@ -271,13 +270,11 @@ class Message(BaseModel):
     tool_calls: Optional[List[ChatCompletionMessageToolCall]] = None
     function_call: Optional[FunctionCall] = None
     control_plane_step: Optional[Dict[str, Any]] = None
+    weight: Optional[int] = None
 
     def dump_mdoel_for_chat_completion_request(self):
         """Only keep chat completion accepted fields"""
-        exclude_fields = (
-            {"control_plane_step", "reasoning_content"} | set(self.model_extra.keys()) if self.model_extra else set()
-        )
-        return self.model_dump(exclude_none=True, exclude=exclude_fields)
+        return self.model_dump(exclude_none=True, exclude={"control_plane_step", "reasoning_content", "weight"})
 
     @classmethod
     def model_validate(cls, obj, *args, **kwargs):

--- a/tests/adapters/test_openai_responses_adapter.py
+++ b/tests/adapters/test_openai_responses_adapter.py
@@ -22,7 +22,7 @@ def test_openai_responses_adapter_with_real_response_simple(snapshot: SnapshotAs
     assert len(eval_rows) == 1
 
     # Convert to dict for snapshot testing
-    eval_rows_dict = [row.model_dump(exclude={"created_at", "execution_metadata"}) for row in eval_rows]
+    eval_rows_dict = [row.model_dump(exclude={"created_at": True, "execution_metadata": True, "messages": {"__all__": {"weight"}}}) for row in eval_rows]
 
     # Assert against snapshot
     assert eval_rows_dict == snapshot
@@ -42,7 +42,7 @@ def test_openai_responses_adapter_with_real_response_parallel_tool_calls(snapsho
     assert len(eval_rows) == 1
 
     # Convert to dict for snapshot testing
-    eval_rows_dict = [row.model_dump(exclude={"created_at", "execution_metadata"}) for row in eval_rows]
+    eval_rows_dict = [row.model_dump(exclude={"created_at": True, "execution_metadata": True, "messages": {"__all__": {"weight"}}}) for row in eval_rows]
 
     # Assert against snapshot
     assert eval_rows_dict == snapshot

--- a/tests/adapters/test_openai_responses_adapter.py
+++ b/tests/adapters/test_openai_responses_adapter.py
@@ -22,7 +22,10 @@ def test_openai_responses_adapter_with_real_response_simple(snapshot: SnapshotAs
     assert len(eval_rows) == 1
 
     # Convert to dict for snapshot testing
-    eval_rows_dict = [row.model_dump(exclude={"created_at": True, "execution_metadata": True, "messages": {"__all__": {"weight"}}}) for row in eval_rows]
+    eval_rows_dict = [
+        row.model_dump(exclude={"created_at": True, "execution_metadata": True, "messages": {"__all__": {"weight"}}})
+        for row in eval_rows
+    ]
 
     # Assert against snapshot
     assert eval_rows_dict == snapshot
@@ -42,7 +45,10 @@ def test_openai_responses_adapter_with_real_response_parallel_tool_calls(snapsho
     assert len(eval_rows) == 1
 
     # Convert to dict for snapshot testing
-    eval_rows_dict = [row.model_dump(exclude={"created_at": True, "execution_metadata": True, "messages": {"__all__": {"weight"}}}) for row in eval_rows]
+    eval_rows_dict = [
+        row.model_dump(exclude={"created_at": True, "execution_metadata": True, "messages": {"__all__": {"weight"}}})
+        for row in eval_rows
+    ]
 
     # Assert against snapshot
     assert eval_rows_dict == snapshot

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -694,3 +694,28 @@ def test_evaluation_row_extra_fields():
     assert "eval" in dictionary
     assert "accuracy" in dictionary["eval_details"]["metrics"]
     assert "test" in dictionary["extra_fields"]
+
+def test_message_with_weight_dump():
+    example = {
+        "role": "user",
+        "content": "Hello, how are you?",
+        "weight": 0,
+    }
+
+    message = Message(**example)
+    dictionary = message.model_dump()
+    assert "weight" in dictionary
+    assert dictionary["weight"] == 0
+
+def test_message_dump_for_chat_completion_request():
+    example = {
+        "role": "user",
+        "content": "Hello, how are you?",
+        "weight": 0,
+        "reasoning_content": "I am thinking about the user's question",
+    }
+    message = Message(**example)
+    dictionary = message.dump_mdoel_for_chat_completion_request()
+    assert "weight" not in dictionary
+    assert "reasoning_content" not in dictionary
+    assert dictionary["content"] == "Hello, how are you?"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -695,6 +695,7 @@ def test_evaluation_row_extra_fields():
     assert "accuracy" in dictionary["eval_details"]["metrics"]
     assert "test" in dictionary["extra_fields"]
 
+
 def test_message_with_weight_dump():
     example = {
         "role": "user",
@@ -706,6 +707,7 @@ def test_message_with_weight_dump():
     dictionary = message.model_dump()
     assert "weight" in dictionary
     assert dictionary["weight"] == 0
+
 
 def test_message_dump_for_chat_completion_request():
     example = {


### PR DESCRIPTION
As titled.

Preserve "weight" set by user in their messages for fine tuning purpose. Also included a new helper function to dump Message to dictionary by filtering out fields that chat completion endpoint doesn't accept