### PR TITLE
fix: resolve argparse conflict for duplicate TypedDict field short flags

### DIFF
--- a/eval_protocol/cli_commands/utils.py
+++ b/eval_protocol/cli_commands/utils.py
@@ -738,7 +738,11 @@ def add_args_from_callable_signature(
                 prefix = name.replace("_", "-")
                 field_kebab = field_name.replace("_", "-")
                 flag_name = f"--{prefix}-{field_kebab}"
-                flags = [flag_name] + aliases.get(f"{name}.{field_name}", []) + [f"--{field_kebab}"]
+                short_flag = f"--{field_kebab}"
+                existing = {s for a in parser._actions for s in a.option_strings}
+                flags = [flag_name] + aliases.get(f"{name}.{field_name}", [])
+                if short_flag not in existing and short_flag != flag_name:
+                    flags.append(short_flag)
                 help_text = help_overrides.get(f"{name}.{field_name}", field_help.get(field_name))
 
                 _add_flag(parser, flags, field_hints.get(field_name, field_type), help_text)

--- a/eval_protocol/cli_commands/utils.py
+++ b/eval_protocol/cli_commands/utils.py
@@ -738,6 +738,8 @@ def add_args_from_callable_signature(
                 prefix = name.replace("_", "-")
                 field_kebab = field_name.replace("_", "-")
                 flag_name = f"--{prefix}-{field_kebab}"
+                # Skip short alias if already claimed by another TypedDict with the same field name
+                # (e.g. AwsS3Config.credentials_secret and AzureBlobStorageConfig.credentials_secret).
                 short_flag = f"--{field_kebab}"
                 existing = {s for a in parser._actions for s in a.option_strings}
                 flags = [flag_name] + aliases.get(f"{name}.{field_name}", [])


### PR DESCRIPTION
## Summary
- Fixes a crash (`ArgumentError: conflicting option string: --credentials-secret`) that occurs on **every** `ep` CLI invocation since the Azure Blob Storage config was added to the Fireworks SDK (`fireworks-ai >= 1.0.0-alpha.58`).
- The root cause is that `add_args_from_callable_signature` unconditionally appends a short alias (`--{field_kebab}`) for every TypedDict field. When two TypedDicts in the same function signature share a field name (e.g., `AwsS3Config.credentials_secret` and `AzureBlobStorageConfig.credentials_secret`), argparse raises a conflict on the duplicate short flag.
- The fix checks whether a short alias is already registered on the parser before adding it. The first TypedDict processed keeps the short alias; subsequent duplicates only get their fully-qualified flag (e.g., `--azure-blob-storage-config-credentials-secret`).

## Test plan
- [ ] Run `ep logs` — should no longer crash
- [ ] Run `ep create rft --help` — verify both `--aws-s3-config-credentials-secret` and `--azure-blob-storage-config-credentials-secret` appear, and `--credentials-secret` appears once (as an alias for the AWS variant)
- [ ] Run `ep upload --help` — verify no regressions on other subcommands


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI argument generation for TypedDict fields and relies on `argparse` internals (`parser._actions`), which could affect flag aliases/help output across commands.
> 
> **Overview**
> Fixes an `argparse` crash when multiple TypedDict parameters share a field name by no longer unconditionally adding the short `--{field}` alias for every TypedDict field.
> 
> `add_args_from_callable_signature` now checks existing parser option strings before appending the short alias, so only the first occurrence claims `--{field}` while subsequent duplicates keep only their fully-qualified flag (plus any configured aliases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2487a3ac42dd00cae508f77c0b8d80ad6feb5fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->