### PR TITLE
fix: use async connection pooling for tracing log polls

### DIFF
--- a/eval_protocol/adapters/fireworks_tracing.py
+++ b/eval_protocol/adapters/fireworks_tracing.py
@@ -6,6 +6,7 @@ to pull data from Langfuse deployments with simplified retry logic handling.
 
 from __future__ import annotations
 import asyncio
+import json
 import logging
 import aiohttp
 import requests
@@ -349,9 +350,9 @@ class FireworksTracingAdapter(BaseAdapter):
                         last_error = f"404 for {url}"
                         continue
                     resp.raise_for_status()
-                    data = (await resp.json()) or {}
+                    data = (await resp.json(content_type=None)) or {}
                     break
-            except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+            except (aiohttp.ClientError, asyncio.TimeoutError, json.JSONDecodeError) as e:
                 last_error = str(e)
                 continue
         else:

--- a/eval_protocol/adapters/fireworks_tracing.py
+++ b/eval_protocol/adapters/fireworks_tracing.py
@@ -5,7 +5,9 @@ to pull data from Langfuse deployments with simplified retry logic handling.
 """
 
 from __future__ import annotations
+import asyncio
 import logging
+import aiohttp
 import requests
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Protocol
@@ -14,6 +16,7 @@ import os
 from eval_protocol.models import EvaluationRow, InputMetadata, ExecutionMetadata, Message
 from .base import BaseAdapter
 from .utils import extract_messages_from_data
+from ..common_utils import get_user_agent
 
 logger = logging.getLogger(__name__)
 
@@ -280,8 +283,6 @@ class FireworksTracingAdapter(BaseAdapter):
         if not tags:
             raise ValueError("At least one tag is required to fetch logs")
 
-        from ..common_utils import get_user_agent
-
         headers = {
             "Authorization": f"Bearer {self._get_api_key()}",
             "User-Agent": get_user_agent(),
@@ -313,6 +314,52 @@ class FireworksTracingAdapter(BaseAdapter):
 
         entries: List[Dict[str, Any]] = data.get("entries", []) or []
         # Normalize minimal shape
+        results: List[Dict[str, Any]] = []
+        for e in entries:
+            results.append(
+                {
+                    "timestamp": e.get("timestamp"),
+                    "message": e.get("message"),
+                    "severity": e.get("severity", "INFO"),
+                    "tags": e.get("tags", []),
+                    "status": e.get("status"),
+                    "extras": e.get("extras"),
+                }
+            )
+        return results
+
+    async def async_search_logs(
+        self, session: aiohttp.ClientSession, tags: List[str], limit: int = 100, hours_back: int = 24
+    ) -> List[Dict[str, Any]]:
+        """Async version of search_logs, reuses a caller-provided aiohttp session."""
+        if not tags:
+            raise ValueError("At least one tag is required to fetch logs")
+
+        params: Dict[str, Any] = {"tags": tags, "limit": limit, "hours_back": hours_back, "program": "eval_protocol"}
+        headers = {"Authorization": f"Bearer {self._get_api_key()}", "User-Agent": get_user_agent()}
+        timeout = aiohttp.ClientTimeout(total=self.timeout)
+
+        urls_to_try = [f"{self.base_url}/logs", f"{self.base_url}/v1/logs"]
+        data: Dict[str, Any] = {}
+        last_error: Optional[str] = None
+        for url in urls_to_try:
+            try:
+                async with session.get(url, params=params, headers=headers, timeout=timeout) as resp:
+                    if resp.status == 404:
+                        last_error = f"404 for {url}"
+                        continue
+                    resp.raise_for_status()
+                    data = (await resp.json()) or {}
+                    break
+            except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+                last_error = str(e)
+                continue
+        else:
+            if last_error:
+                logger.error("Failed to fetch logs from Fireworks (tried %s): %s", urls_to_try, last_error)
+            return []
+
+        entries: List[Dict[str, Any]] = data.get("entries", []) or []
         results: List[Dict[str, Any]] = []
         for e in entries:
             results.append(
@@ -410,8 +457,6 @@ class FireworksTracingAdapter(BaseAdapter):
             url = f"{self.base_url}/v1/project_id/{self.project_id}/traces/pointwise"
         else:
             url = f"{self.base_url}/v1/traces/pointwise"
-
-        from ..common_utils import get_user_agent
 
         headers = {
             "Authorization": f"Bearer {self._get_api_key()}",

--- a/eval_protocol/pytest/remote_rollout_processor.py
+++ b/eval_protocol/pytest/remote_rollout_processor.py
@@ -52,7 +52,8 @@ class RemoteRolloutProcessor(RolloutProcessor):
 
     def _get_or_create_session(self) -> aiohttp.ClientSession:
         if self._session is None or self._session.closed:
-            self._session = aiohttp.ClientSession()
+            connector = aiohttp.TCPConnector(limit=0)  # no total connection limit
+            self._session = aiohttp.ClientSession(connector=connector)
         return self._session
 
     def __call__(self, rows: List[EvaluationRow], config: RolloutProcessorConfig) -> List[asyncio.Task[EvaluationRow]]:
@@ -99,7 +100,7 @@ class RemoteRolloutProcessor(RolloutProcessor):
             # Fire-and-poll
             init_url = f"{remote_base_url}/init"
 
-            timeout_init = aiohttp.ClientTimeout(total=300)
+            timeout_init = aiohttp.ClientTimeout(total=600)
 
             try:
                 session = self._get_or_create_session()
@@ -114,15 +115,15 @@ class RemoteRolloutProcessor(RolloutProcessor):
                     await resp.read()  # Drain the response body and release the connection back to the pool
             except asyncio.TimeoutError:
                 raise TimeoutError(
-                    f"The /init endpoint tried {init_url} with {init_payload.model_dump()} but timed out after 300 seconds."
+                    f"The /init endpoint tried {init_url} with {init_payload.model_dump()} but timed out after 600 seconds."
                 )
 
             deadline = time.time() + timeout_seconds
 
             while time.time() < deadline:
-                # Search Fireworks tracing logs for completion (run in thread to avoid blocking event loop)
-                completed_logs = await asyncio.to_thread(
-                    self._tracing_adapter.search_logs, tags=[f"rollout_id:{row.execution_metadata.rollout_id}"]
+                session = self._get_or_create_session()
+                completed_logs = await self._tracing_adapter.async_search_logs(
+                    session, tags=[f"rollout_id:{row.execution_metadata.rollout_id}"]
                 )
                 # Filter for logs that actually have status information
                 status_logs = []


### PR DESCRIPTION
## Summary

- Add `async_search_logs` to `FireworksTracingAdapter` — native async version of `search_logs` that accepts a caller-provided `aiohttp.ClientSession` for connection reuse
- Switch `RemoteRolloutProcessor` from `asyncio.to_thread(search_logs)` to `await async_search_logs(session)`, reusing the same shared session used for `/init` calls
- Remove default connection pool cap (`TCPConnector(limit=0)`) so the semaphore is the only concurrency bound
- Increase `/init` timeout from 300s to 600s
- Move `common_utils.get_user_agent` import to module level

## Problem

Under high concurrency, customers see frequent SSL EOF errors when polling `tracing.fireworks.ai/logs`:

```
HTTPSConnectionPool(host='tracing.fireworks.ai', port=443): Max retries exceeded
(Caused by SSLError(SSLEOFError(8, '[SSL: UNEXPECTED_EOF_WHILE_READING]')))
```

Root cause: `search_logs` used bare `requests.get()` via `asyncio.to_thread` — every poll opened a new TCP+TLS connection. With N concurrent rows polling every few seconds, this created N fresh TLS handshakes per poll cycle, overwhelming the server.

## Fix

Reuse the `RemoteRolloutProcessor`'s existing `aiohttp.ClientSession` for trace polling. Connections are kept alive and reused across polls, reducing TLS handshake volume from `N_rows × N_polls` to ~`N_rows`.

```mermaid
sequenceDiagram
    participant RRP as RemoteRolloutProcessor
    participant Session as aiohttp.ClientSession<br/>(shared, limit=0)
    participant Rollr as Rollr Server
    participant Tracing as tracing.fireworks.ai

    RRP->>Session: _get_or_create_session()
    Session-->>RRP: session (reused)

    RRP->>Session: session.post(/init)
    Session->>Rollr: POST /init (reuses conn)
    Rollr-->>Session: 200 OK

    loop Poll until status found
        RRP->>Session: async_search_logs(session)
        Session->>Tracing: GET /logs (reuses conn)
        Tracing-->>Session: entries
    end
```

## Test plan

- [x] `test_remote_fireworks_propagate_status` — passed locally
- [x] `test_remote_fireworks` — `/init` + `/logs` polling passed; downstream trace-fetch 404 is a pre-existing timing issue
- [ ] CI: `fireworks-tracing-tests` workflow

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches async networking and connection pooling used during remote rollout polling; mistakes could cause stuck polls, leaked sessions, or changed timeout behavior under load.
> 
> **Overview**
> Improves remote rollout polling by adding `FireworksTracingAdapter.async_search_logs(...)` (aiohttp-based) and switching `RemoteRolloutProcessor` to await it instead of calling `requests` via `asyncio.to_thread`, enabling connection reuse.
> 
> Also updates the shared `aiohttp` session to use an unbounded `TCPConnector(limit=0)` and increases the remote `/init` request timeout from 300s to 600s; `get_user_agent` is now imported at module scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e628aef258de8601384b2d4f7cd2bb26d02429a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->