### PR TITLE
feat: two-phase status polling via lightweight /status endpoint

### DIFF
--- a/eval_protocol/adapters/fireworks_tracing.py
+++ b/eval_protocol/adapters/fireworks_tracing.py
@@ -379,7 +379,7 @@ class FireworksTracingAdapter(BaseAdapter):
         """Fetch rollout status from the lightweight /status endpoint.
 
         Returns the parsed JSON response or None if the status is not yet available.
-        Response shape: {"rollout_id": "...", "status": {"code": ...} | null}
+        Response shape: {"rollout_id": "...", "status": {"code": ...} | null, "extras": {...} | null}
         """
         headers = {
             "Authorization": f"Bearer {self._get_api_key()}",

--- a/eval_protocol/adapters/fireworks_tracing.py
+++ b/eval_protocol/adapters/fireworks_tracing.py
@@ -375,31 +375,30 @@ class FireworksTracingAdapter(BaseAdapter):
             )
         return results
 
-    def get_status(self, rollout_id: str) -> Optional[Dict[str, Any]]:
+    async def async_get_status(self, session: aiohttp.ClientSession, rollout_id: str) -> Optional[Dict[str, Any]]:
         """Fetch rollout status from the lightweight /status endpoint.
 
         Returns the parsed JSON response or None if the status is not yet available.
         Response shape: {"rollout_id": "...", "status": {"code": ...} | null}
         """
-        from ..common_utils import get_user_agent
-
         headers = {
             "Authorization": f"Bearer {self._get_api_key()}",
             "User-Agent": get_user_agent(),
         }
         params: Dict[str, Any] = {"rollout_id": rollout_id}
+        timeout = aiohttp.ClientTimeout(total=self.timeout)
 
-        urls_to_try = [f"{self.base_url}/status", f"{self.base_url}/v1/status"]
+        urls_to_try = [f"{self.base_url}/v1/status", f"{self.base_url}/status"]
         last_error: Optional[str] = None
         for url in urls_to_try:
             try:
-                response = requests.get(url, params=params, timeout=self.timeout, headers=headers)
-                if response.status_code == 404:
-                    last_error = f"404 for {url}"
-                    continue
-                response.raise_for_status()
-                return response.json()
-            except requests.exceptions.RequestException as e:
+                async with session.get(url, params=params, headers=headers, timeout=timeout) as resp:
+                    if resp.status == 404:
+                        last_error = f"404 for {url}"
+                        continue
+                    resp.raise_for_status()
+                    return (await resp.json(content_type=None)) or {}
+            except (aiohttp.ClientError, asyncio.TimeoutError, json.JSONDecodeError) as e:
                 last_error = str(e)
                 continue
 

--- a/eval_protocol/adapters/fireworks_tracing.py
+++ b/eval_protocol/adapters/fireworks_tracing.py
@@ -375,6 +375,38 @@ class FireworksTracingAdapter(BaseAdapter):
             )
         return results
 
+    def get_status(self, rollout_id: str) -> Optional[Dict[str, Any]]:
+        """Fetch rollout status from the lightweight /status endpoint.
+
+        Returns the parsed JSON response or None if the status is not yet available.
+        Response shape: {"rollout_id": "...", "status": {"code": ...} | null}
+        """
+        from ..common_utils import get_user_agent
+
+        headers = {
+            "Authorization": f"Bearer {self._get_api_key()}",
+            "User-Agent": get_user_agent(),
+        }
+        params: Dict[str, Any] = {"rollout_id": rollout_id}
+
+        urls_to_try = [f"{self.base_url}/status", f"{self.base_url}/v1/status"]
+        last_error: Optional[str] = None
+        for url in urls_to_try:
+            try:
+                response = requests.get(url, params=params, timeout=self.timeout, headers=headers)
+                if response.status_code == 404:
+                    last_error = f"404 for {url}"
+                    continue
+                response.raise_for_status()
+                return response.json()
+            except requests.exceptions.RequestException as e:
+                last_error = str(e)
+                continue
+
+        if last_error:
+            logger.error("Failed to fetch status from Fireworks (tried %s): %s", urls_to_try, last_error)
+        return None
+
     def get_evaluation_rows(
         self,
         tags: List[str],

--- a/eval_protocol/pytest/remote_rollout_processor.py
+++ b/eval_protocol/pytest/remote_rollout_processor.py
@@ -152,7 +152,7 @@ class RemoteRolloutProcessor(RolloutProcessor):
                         details=status_details,
                     )
 
-                    status_extras = status.get("extras")
+                    status_extras = (status_result or {}).get("extras")
                     if isinstance(status_extras, dict):
                         if row.execution_metadata.extra:
                             row.execution_metadata.extra.update(status_extras)

--- a/eval_protocol/pytest/remote_rollout_processor.py
+++ b/eval_protocol/pytest/remote_rollout_processor.py
@@ -121,46 +121,39 @@ class RemoteRolloutProcessor(RolloutProcessor):
             deadline = time.time() + timeout_seconds
 
             while time.time() < deadline:
-                session = self._get_or_create_session()
-                completed_logs = await self._tracing_adapter.async_search_logs(
-                    session, tags=[f"rollout_id:{row.execution_metadata.rollout_id}"]
+                # Poll status (run in thread to avoid blocking event loop)
+                status_result = await asyncio.to_thread(
+                    self._tracing_adapter.get_status, rollout_id=row.execution_metadata.rollout_id
                 )
-                # Filter for logs that actually have status information
-                status_logs = []
-                for log in completed_logs:
-                    status_dict = log.get("status")
-                    if status_dict and isinstance(status_dict, dict) and "code" in status_dict:
-                        status_logs.append(log)
-
-                if status_logs:
-                    if len(status_logs) > 1:
-                        logger.warning(
-                            "Found %s status logs for rollout %s; expected at most 1. Using the first one: %s",
-                            len(status_logs),
-                            row.execution_metadata.rollout_id,
-                            status_logs[0],
-                        )
-                    # Use the first log with status information
-                    status_log = status_logs[0]
-                    status_dict = status_log.get("status")
-                    raw_extras = status_log.get("extras") or {}
-                    status_extras = {
-                        k: v for k, v in raw_extras.items() if k not in ("logger_name", "level", "timestamp")
-                    }
+                if status_result and status_result.get("status"):
+                    status_code = status_result["status"]["code"]
 
                     logger.info(
-                        f"Found status log for rollout {row.execution_metadata.rollout_id}: {status_log.get('message', '')}"
+                        "Found status for rollout %s with code %s",
+                        row.execution_metadata.rollout_id,
+                        status_code,
                     )
 
-                    status_code = status_dict.get("code")
-                    status_message = status_dict.get("message", "")
-                    status_details = status_dict.get("details", [])
-
-                    logger.info(
-                        f"Found Fireworks log for rollout {row.execution_metadata.rollout_id} with status code {status_code}"
+                    # Backfill message/details/extras from the full Logs table (one-shot)
+                    completed_logs = await asyncio.to_thread(
+                        self._tracing_adapter.search_logs,
+                        tags=[f"rollout_id:{row.execution_metadata.rollout_id}"],
                     )
+                    status_message = ""
+                    status_details: list = []
+                    status_extras: dict = {}
+                    for log in completed_logs:
+                        sd = log.get("status")
+                        if sd and isinstance(sd, dict) and "code" in sd:
+                            status_message = sd.get("message", "")
+                            status_details = sd.get("details", [])
+                            raw_extras = log.get("extras") or {}
+                            status_extras = {
+                                k: v for k, v in raw_extras.items()
+                                if k not in ("logger_name", "level", "timestamp")
+                            }
+                            break
 
-                    # Create and raise exception if appropriate, preserving original message
                     exception = exception_for_status_code(status_code, status_message)
                     if exception is not None:
                         raise exception

--- a/eval_protocol/pytest/remote_rollout_processor.py
+++ b/eval_protocol/pytest/remote_rollout_processor.py
@@ -125,8 +125,13 @@ class RemoteRolloutProcessor(RolloutProcessor):
                 status_result = await asyncio.to_thread(
                     self._tracing_adapter.get_status, rollout_id=row.execution_metadata.rollout_id
                 )
-                if status_result and status_result.get("status"):
-                    status_code = status_result["status"]["code"]
+                status = (status_result or {}).get("status")
+                if status and "code" in status:
+                    status_code = status["code"]
+
+                    if status_code == Status.Code.RUNNING:
+                        await asyncio.sleep(poll_interval)
+                        continue
 
                     logger.info(
                         "Found status for rollout %s with code %s",

--- a/eval_protocol/pytest/remote_rollout_processor.py
+++ b/eval_protocol/pytest/remote_rollout_processor.py
@@ -129,6 +129,9 @@ class RemoteRolloutProcessor(RolloutProcessor):
                 status = (status_result or {}).get("status")
                 if isinstance(status, dict) and "code" in status:
                     status_code = status["code"]
+                    if status_code == Status.Code.RUNNING:
+                        await asyncio.sleep(poll_interval)
+                        continue
 
                     logger.info(
                         "Found status for rollout %s with code %s",

--- a/eval_protocol/pytest/remote_rollout_processor.py
+++ b/eval_protocol/pytest/remote_rollout_processor.py
@@ -121,17 +121,14 @@ class RemoteRolloutProcessor(RolloutProcessor):
             deadline = time.time() + timeout_seconds
 
             while time.time() < deadline:
-                # Poll status (run in thread to avoid blocking event loop)
-                status_result = await asyncio.to_thread(
-                    self._tracing_adapter.get_status, rollout_id=row.execution_metadata.rollout_id
+                session = self._get_or_create_session()
+                status_result = await self._tracing_adapter.async_get_status(
+                    session,
+                    rollout_id=row.execution_metadata.rollout_id,
                 )
                 status = (status_result or {}).get("status")
-                if status and "code" in status:
+                if isinstance(status, dict) and "code" in status:
                     status_code = status["code"]
-
-                    if status_code == Status.Code.RUNNING:
-                        await asyncio.sleep(poll_interval)
-                        continue
 
                     logger.info(
                         "Found status for rollout %s with code %s",
@@ -139,25 +136,8 @@ class RemoteRolloutProcessor(RolloutProcessor):
                         status_code,
                     )
 
-                    # Backfill message/details/extras from the full Logs table (one-shot)
-                    session = self._get_or_create_session()
-                    completed_logs = await self._tracing_adapter.async_search_logs(
-                        session, tags=[f"rollout_id:{row.execution_metadata.rollout_id}"],
-                    )
-                    status_message = ""
-                    status_details: list = []
-                    status_extras: dict = {}
-                    for log in completed_logs:
-                        sd = log.get("status")
-                        if sd and isinstance(sd, dict) and "code" in sd:
-                            status_message = sd.get("message", "")
-                            status_details = sd.get("details", [])
-                            raw_extras = log.get("extras") or {}
-                            status_extras = {
-                                k: v for k, v in raw_extras.items()
-                                if k not in ("logger_name", "level", "timestamp")
-                            }
-                            break
+                    status_message = status.get("message", "") or ""
+                    status_details = status.get("details", []) or []
 
                     exception = exception_for_status_code(status_code, status_message)
                     if exception is not None:
@@ -169,10 +149,12 @@ class RemoteRolloutProcessor(RolloutProcessor):
                         details=status_details,
                     )
 
-                    if row.execution_metadata.extra:
-                        row.execution_metadata.extra.update(status_extras)
-                    else:
-                        row.execution_metadata.extra = status_extras
+                    status_extras = status.get("extras")
+                    if isinstance(status_extras, dict):
+                        if row.execution_metadata.extra:
+                            row.execution_metadata.extra.update(status_extras)
+                        else:
+                            row.execution_metadata.extra = status_extras
 
                     logger.info("Stopping polling for rollout %s", row.execution_metadata.rollout_id)
                     break

--- a/eval_protocol/pytest/remote_rollout_processor.py
+++ b/eval_protocol/pytest/remote_rollout_processor.py
@@ -140,9 +140,9 @@ class RemoteRolloutProcessor(RolloutProcessor):
                     )
 
                     # Backfill message/details/extras from the full Logs table (one-shot)
-                    completed_logs = await asyncio.to_thread(
-                        self._tracing_adapter.search_logs,
-                        tags=[f"rollout_id:{row.execution_metadata.rollout_id}"],
+                    session = self._get_or_create_session()
+                    completed_logs = await self._tracing_adapter.async_search_logs(
+                        session, tags=[f"rollout_id:{row.execution_metadata.rollout_id}"],
                     )
                     status_message = ""
                     status_details: list = []


### PR DESCRIPTION
## Summary
- Adds `get_status()` to `FireworksTracingAdapter` that calls the new `/status` endpoint on the tracing gateway for fast rollout status lookups.
- Replaces the polling loop in `RemoteRolloutProcessor` with a two-phase approach: poll `/status` for the status code (lightweight point-read), then make a single `search_logs` call to backfill message/details/extras.

This reduces the hot-path read load on the Logs table from ~1000 RPS to a single read per rollout completion. Depends on the tracing gateway PR that adds the `/status` endpoint and `Status` Spanner table ([mono PR](https://github.com/fw-ai/fireworks/pull/$(cd /Users/sandeepsingh/src/fireworks/mono && gh pr view --json number -q .number 2>/dev/null || echo "TBD"))).

## Test plan
- [ ] Verify `get_status()` returns status when available, `None` when not
- [ ] Verify `RemoteRolloutProcessor` polls `/status` first, then fetches full logs once
- [ ] Run end-to-end eval with remote rollout to confirm no regressions

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote rollout completion polling logic and introduces a new tracing gateway call path, which could affect rollout completion detection and timeout behavior if the `/status` response shape/availability differs across deployments.
> 
> **Overview**
> Adds `FireworksTracingAdapter.get_status()` to query a lightweight tracing gateway `/status` (with `/v1/status` fallback) for rollout status codes.
> 
> Updates `RemoteRolloutProcessor` to use a **two-phase polling flow**: repeatedly poll `get_status()` until the rollout leaves `RUNNING`, then perform a single `async_search_logs()` call to backfill status `message`/`details` and propagate `extras` into `execution_metadata.extra`, reducing repeated log-table reads during polling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a17c9b8fb9d77c0155bdd38df0e9dcaedd411ae7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->