### PR TITLE
fix: support request-scoped rollout logging config

### DIFF
--- a/typescript/logging/fireworks-transport.ts
+++ b/typescript/logging/fireworks-transport.ts
@@ -45,6 +45,7 @@ export class FireworksTransport extends Transport {
 
   constructor(opts: {
     gatewayBaseUrl?: string;
+    apiKey?: string;
     rolloutIdEnv?: string;
     waitUntil?: (promise: Promise<any>) => void;
   } = {}) {
@@ -56,7 +57,7 @@ export class FireworksTransport extends Transport {
       'https://tracing.fireworks.ai';
 
     this.rolloutIdEnv = opts.rolloutIdEnv || 'EP_ROLLOUT_ID';
-    this.apiKey = process.env.FIREWORKS_API_KEY;
+    this.apiKey = opts.apiKey || process.env.FIREWORKS_API_KEY;
     this.waitUntil = opts.waitUntil;
   }
 

--- a/typescript/logging/logger.ts
+++ b/typescript/logging/logger.ts
@@ -5,6 +5,12 @@
 import winston from 'winston';
 import { FireworksTransport } from './fireworks-transport.js';
 
+type RolloutLoggerOptions = {
+  gatewayBaseUrl?: string;
+  apiKey?: string;
+  name?: string;
+};
+
 // Global reference to waitUntil function
 let globalWaitUntil: ((promise: Promise<any>) => void) | undefined;
 
@@ -36,9 +42,41 @@ export const logger = winston.createLogger({
 /**
  * Create a child logger with rollout_id context.
  */
-export function createRolloutLogger(rolloutId: string, name: string = 'init'): winston.Logger {
-  return logger.child({
+export function createRolloutLogger(
+  rolloutId: string,
+  nameOrOptions: string | RolloutLoggerOptions = 'init'
+): winston.Logger {
+  const options = typeof nameOrOptions === 'string' ? { name: nameOrOptions } : nameOrOptions;
+  const name = options.name || 'init';
+  const defaultMeta = {
     rollout_id: rolloutId,
     logger_name: `${name}.${rolloutId}`
-  });
+  };
+
+  if (options.gatewayBaseUrl || options.apiKey) {
+    return winston.createLogger({
+      level: 'info',
+      format: winston.format.combine(
+        winston.format.timestamp(),
+        winston.format.errors({ stack: true }),
+        winston.format.json()
+      ),
+      defaultMeta,
+      transports: [
+        new winston.transports.Console({
+          format: winston.format.combine(
+            winston.format.colorize(),
+            winston.format.simple()
+          )
+        }),
+        new FireworksTransport({
+          gatewayBaseUrl: options.gatewayBaseUrl,
+          apiKey: options.apiKey,
+          waitUntil: (promise: Promise<any>) => globalWaitUntil?.(promise)
+        })
+      ]
+    });
+  }
+
+  return logger.child(defaultMeta);
 }


### PR DESCRIPTION
## Summary
- Add request-scoped `gatewayBaseUrl` and `apiKey` support to the TypeScript Fireworks logging transport.
- Extend `createRolloutLogger` to accept an options object while preserving the existing string-name call shape.
- Keep API keys inside the transport instance rather than attaching them to log metadata.

## Test plan
- `npx tsc --noEmit` from `typescript/`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c4aa43a5e66e2f5f4c8a3dc72b9f4fde9d58919f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->