### PR TITLE
fix: backfill rollout status fields from logs when polling completes

### DIFF
--- a/eval_protocol/pytest/remote_rollout_processor.py
+++ b/eval_protocol/pytest/remote_rollout_processor.py
@@ -146,9 +146,12 @@ class RemoteRolloutProcessor(RolloutProcessor):
                     completed_logs = await self._tracing_adapter.async_search_logs(
                         session, tags=[f"rollout_id:{row.execution_metadata.rollout_id}"]
                     )
+                    # Pick the log row whose status code matches the terminal
+                    # code from /status, so intermediate RUNNING checkpoints
+                    # don't poison the backfill.
                     for log in completed_logs:
                         sd = log.get("status")
-                        if sd and isinstance(sd, dict) and "code" in sd:
+                        if isinstance(sd, dict) and sd.get("code") == status_code:
                             status_message = sd.get("message", "") or ""
                             status_details = sd.get("details", []) or []
                             raw_extras = log.get("extras") or {}

--- a/eval_protocol/pytest/remote_rollout_processor.py
+++ b/eval_protocol/pytest/remote_rollout_processor.py
@@ -139,8 +139,25 @@ class RemoteRolloutProcessor(RolloutProcessor):
                         status_code,
                     )
 
-                    status_message = status.get("message", "") or ""
-                    status_details = status.get("details", []) or []
+                    # /status only returns the code; backfill message/details/extras from Logs once.
+                    status_message: str = ""
+                    status_details: list = []
+                    status_extras: dict = {}
+                    completed_logs = await self._tracing_adapter.async_search_logs(
+                        session, tags=[f"rollout_id:{row.execution_metadata.rollout_id}"]
+                    )
+                    for log in completed_logs:
+                        sd = log.get("status")
+                        if sd and isinstance(sd, dict) and "code" in sd:
+                            status_message = sd.get("message", "") or ""
+                            status_details = sd.get("details", []) or []
+                            raw_extras = log.get("extras") or {}
+                            status_extras = {
+                                k: v
+                                for k, v in raw_extras.items()
+                                if k not in ("logger_name", "level", "timestamp")
+                            }
+                            break
 
                     exception = exception_for_status_code(status_code, status_message)
                     if exception is not None:
@@ -152,8 +169,7 @@ class RemoteRolloutProcessor(RolloutProcessor):
                         details=status_details,
                     )
 
-                    status_extras = (status_result or {}).get("extras")
-                    if isinstance(status_extras, dict):
+                    if status_extras:
                         if row.execution_metadata.extra:
                             row.execution_metadata.extra.update(status_extras)
                         else:


### PR DESCRIPTION
## Summary

`Fireworks Tracing Tests` is red on `main` and on every PR — see [run 25409077579](https://github.com/eval-protocol/python-sdk/actions/runs/25409077579). The failure is a regression introduced by #446:

```
ERROR:root:❌ Rollout failed (non-retryable error encountered): InternalError()
    assert row.rollout_status.message == "test error"
E   AssertionError: assert '' == 'test error'
```

The lightweight `/status` endpoint on the tracing gateway is a point-read on the `Status` Spanner table, which only stores `RolloutId`, `AccountId`, `StatusCode`. `Message`, `Details`, and `Extras` still live exclusively on the `Logs` table. After #446 dropped the `/logs` backfill (commit `20b0f23`), the SDK was constructing `Status(code=..., message="", details=[])` on every completed rollout and `EvalProtocolError(message="")` on every failure — which is what the propagate-status integration test catches.

This PR restores the two-phase polling shape from the original design of #446:

1. Poll `/status` for the status code (cheap point-read, runs every `poll_interval`).
2. On a terminal (non-`RUNNING`) code, do exactly one `async_search_logs` call to backfill `message` / `details` / `extras` from the matching log row.

That's still ~1000× cheaper on the `Logs` table than the pre-#446 polling loop, because the search runs once per rollout completion instead of every poll interval.

The cleanest long-term fix is on the gateway side: extend either the `Status` Spanner schema (and `spanner_reader.get_status`) to also persist these fields, or have the `/status` handler do an internal `Logs` read on terminal codes and inline them into the response. Either change would let the SDK go back to a single read per completion. Filing a follow-up for that.

## Test plan

- [ ] `Fireworks Tracing Tests` workflow goes green on this branch.
- [ ] `test_remote_rollout_and_fetch_fireworks` (happy path) still passes.
- [ ] `test_remote_rollout_and_fetch_fireworks_propagate_status` sees `Code.INTERNAL` with `message == "test error"`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes terminal-status handling in `RemoteRolloutProcessor` by adding a one-time logs lookup and merging returned extras, which affects error propagation and could introduce edge cases if log entries are missing or mismatched.
> 
> **Overview**
> Restores two-phase rollout polling in `RemoteRolloutProcessor`: continue polling `/status` for the status *code*, then on a terminal code perform a single `async_search_logs` query to backfill `Status.message`, `Status.details`, and execution `extras`.
> 
> When backfilling, it selects the log entry whose embedded status `code` matches the terminal `/status` code (avoiding intermediate `RUNNING` checkpoints) and filters out noisy extras keys before merging into `row.execution_metadata.extra`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3298857d7b2d8aaaa040e6123b554f496833b3ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->