### PR TITLE
Fix typo "mdoel" -> "model" in dump_mdoel_for_chat_completion_request

### DIFF
--- a/eval_protocol/models.py
+++ b/eval_protocol/models.py
@@ -525,7 +525,7 @@ class Message(BaseModel):
         ),
     )
 
-    def dump_mdoel_for_chat_completion_request(self):
+    def dump_model_for_chat_completion_request(self):
         """Only keep chat completion accepted fields"""
         return self.model_dump(
             exclude_none=True,

--- a/eval_protocol/pytest/default_agent_rollout_processor.py
+++ b/eval_protocol/pytest/default_agent_rollout_processor.py
@@ -141,8 +141,8 @@ class Agent:
         # Convert Message models to plain dicts for LLM call
         # Filter out fields that are not supported by OpenAI/LiteLLM APIs (e.g., weight, control_plane_step, reasoning_content)
         messages_payload: List[Dict[str, Any]] = [
-            message.dump_mdoel_for_chat_completion_request()
-            if hasattr(message, "dump_mdoel_for_chat_completion_request")
+            message.dump_model_for_chat_completion_request()
+            if hasattr(message, "dump_model_for_chat_completion_request")
             else (message.model_dump() if hasattr(message, "model_dump") else message)  # type: ignore[misc]
             for message in messages
         ]

--- a/eval_protocol/pytest/default_single_turn_rollout_process.py
+++ b/eval_protocol/pytest/default_single_turn_rollout_process.py
@@ -76,7 +76,7 @@ class SingleTurnRolloutProcessor(RolloutProcessor):
 
             # Filter out fields that are not supported by OpenAI/LiteLLM APIs (e.g., weight, control_plane_step, reasoning_content)
             # Use the Message class method that excludes unsupported fields
-            messages_payload = [message.dump_mdoel_for_chat_completion_request() for message in messages_for_request]
+            messages_payload = [message.dump_model_for_chat_completion_request() for message in messages_for_request]
 
             # Normalize Fireworks model names for LiteLLM routing
             completion_params = normalize_fireworks_model_for_litellm(config.completion_params) or {}

--- a/eval_protocol/pytest/tracing_utils.py
+++ b/eval_protocol/pytest/tracing_utils.py
@@ -157,13 +157,13 @@ def build_init_request(
     completion_params_base_url: Optional[str] = completion_params_dict.get("base_url")
 
     # Strip non-OpenAI fields from messages
-    # Use dump_mdoel_for_chat_completion_request() to automatically exclude unsupported fields (weight, control_plane_step, reasoning_content)
+    # Use dump_model_for_chat_completion_request() to automatically exclude unsupported fields (weight, control_plane_step, reasoning_content)
     clean_messages = []
     for m in row.messages:
         md: Dict[str, Any]
-        if hasattr(m, "dump_mdoel_for_chat_completion_request"):
+        if hasattr(m, "dump_model_for_chat_completion_request"):
             # Use the Message method that automatically filters unsupported fields
-            md = m.dump_mdoel_for_chat_completion_request()
+            md = m.dump_model_for_chat_completion_request()
         elif hasattr(m, "model_dump"):
             md = m.model_dump()
         elif isinstance(m, dict):
@@ -177,7 +177,7 @@ def build_init_request(
                 "tool_call_id": getattr(m, "tool_call_id", None),
                 "name": getattr(m, "name", None),
             }
-        # Additional filtering to ensure only allowed fields are kept (already handled by dump_mdoel_for_chat_completion_request for Message objects)
+        # Additional filtering to ensure only allowed fields are kept (already handled by dump_model_for_chat_completion_request for Message objects)
         allowed_message_fields = {"role", "content", "tool_calls", "tool_call_id", "name"}
         clean_messages.append({k: v for k, v in md.items() if k in allowed_message_fields and v is not None})
 

--- a/scripts/test_remote_rollout_prompt_token_ids.py
+++ b/scripts/test_remote_rollout_prompt_token_ids.py
@@ -42,7 +42,7 @@ def _free_port() -> int:
 
 def _message_to_dict(message: Message | dict[str, Any]) -> dict[str, Any]:
     if isinstance(message, Message):
-        return message.dump_mdoel_for_chat_completion_request()
+        return message.dump_model_for_chat_completion_request()
     return {k: v for k, v in dict(message).items() if v is not None}
 
 

--- a/tests/remote_server/remote_server.py
+++ b/tests/remote_server/remote_server.py
@@ -44,8 +44,8 @@ def init(req: InitRequest):
             # excluding any None fields (Fireworks rejects extra keys even when null).
             messages_payload = []
             for m in req.messages:
-                if hasattr(m, "dump_mdoel_for_chat_completion_request"):
-                    md = m.dump_mdoel_for_chat_completion_request()  # type: ignore[attr-defined]
+                if hasattr(m, "dump_model_for_chat_completion_request"):
+                    md = m.dump_model_for_chat_completion_request()  # type: ignore[attr-defined]
                 elif hasattr(m, "model_dump"):
                     md = m.model_dump(exclude_none=True)  # type: ignore[call-arg]
                 elif isinstance(m, dict):

--- a/tests/test_message_field_filtering.py
+++ b/tests/test_message_field_filtering.py
@@ -9,7 +9,7 @@ from eval_protocol.models import Message
 
 
 def test_dump_model_excludes_unsupported_fields():
-    """Test that dump_mdoel_for_chat_completion_request excludes unsupported fields."""
+    """Test that dump_model_for_chat_completion_request excludes unsupported fields."""
     # Create a message with all possible fields including unsupported ones
     message = Message(
         role="user",
@@ -21,7 +21,7 @@ def test_dump_model_excludes_unsupported_fields():
     )
 
     # Get the filtered dictionary
-    filtered = message.dump_mdoel_for_chat_completion_request()
+    filtered = message.dump_model_for_chat_completion_request()
 
     # Verify unsupported fields are excluded
     assert "weight" not in filtered, "weight field should be excluded"
@@ -48,7 +48,7 @@ def test_dump_model_with_only_supported_fields():
         tool_call_id=None,
     )
 
-    filtered = message.dump_mdoel_for_chat_completion_request()
+    filtered = message.dump_model_for_chat_completion_request()
 
     # Should only contain supported fields
     assert filtered["role"] == "assistant"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -718,7 +718,7 @@ def test_message_dump_for_chat_completion_request():
         "reasoning_content": "I am thinking about the user's question",
     }
     message = Message(**example)
-    dictionary = message.dump_mdoel_for_chat_completion_request()
+    dictionary = message.dump_model_for_chat_completion_request()
     assert "weight" not in dictionary
     assert "reasoning_content" not in dictionary
     assert dictionary["content"] == "Hello, how are you?"


### PR DESCRIPTION
As title.

Pretty sure this should have been model and not mdoel. Please enlighten me otherwise ;) 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure identifier rename with no logic changes; low risk unless external code still calls the old misspelled method name.
> 
> **Overview**
> Renames `Message.dump_mdoel_for_chat_completion_request` to **`dump_model_for_chat_completion_request`** (typo fix: mdoel → model).
> 
> All call sites are updated in rollout processors (`default_agent_rollout_processor`, `default_single_turn_rollout_process`, `tracing_utils`), remote test server and e2e script, and related tests/comments. **Behavior is unchanged**—still strips non–chat-completion fields before API requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd9b22f12a1033aac35ca1c3f4f12a85828093f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->