### PR TITLE
fix: recover per-token ids and logprobs from content[] to stop RL KLD corruption

### DIFF
--- a/eval_protocol/integrations/fireworks_v1_completions_client.py
+++ b/eval_protocol/integrations/fireworks_v1_completions_client.py
@@ -83,6 +83,19 @@ def _normalize_token_id_sequence(values: Any) -> List[int]:
     return [int(x) for x in list(values)]
 
 
+def _extract_entry_logprob(entry: Dict[str, Any]) -> float:
+    """Return the per-token logprob from a ``content[]`` logprobs entry.
+
+    Prefer ``sampling_logprob`` (the exact, full-precision value the sampler
+    actually drew with) over ``logprob`` (a rounded/verification value). The
+    sampler value is what RL training needs for accurate inference KLD.
+    """
+    value = entry.get("sampling_logprob")
+    if value is None:
+        value = entry.get("logprob", 0.0)
+    return float(value) if value is not None else 0.0
+
+
 def _coerce_message_content_to_text(content: Any) -> str:
     if content is None:
         return ""
@@ -358,12 +371,6 @@ class FireworksV1CompletionsClient:
         }
         if not self.logprobs:
             request_payload.pop("logprobs", None)
-        # Always request the exact generated token ids so downstream RL training
-        # can align per-token logprobs to token ids position-by-position.
-        # Re-encoding decoded text drops the trailing end-of-turn/EOS token and
-        # misaligns logprobs, corrupting inference KLD. Keep overridable via
-        # request_params, but default the flag on.
-        request_payload.setdefault("return_token_ids", True)
 
         max_retries = 40
         base_delay = 10.0
@@ -399,51 +406,43 @@ class FireworksV1CompletionsClient:
         finish_reason = str(choice.get("finish_reason") or "unknown")
 
         raw_output = choice.get("raw_output") if isinstance(choice.get("raw_output"), dict) else {}
-        completion_token_ids = _normalize_token_id_sequence(
-            choice.get("token_ids") or raw_output.get("completion_token_ids") or []
-        )
-        if not completion_token_ids:
-            raise RuntimeError(
-                "Fireworks /v1/completions returned no exact completion token IDs "
-                "(choices[].token_ids and raw_output.completion_token_ids both empty) "
-                "even though return_token_ids=True was requested. "
-                "Refusing to re-encode decoded text: retokenization drops the "
-                "end-of-turn token and misaligns per-token logprobs, corrupting "
-                f"inference KLD. choice keys={list(choice.keys())}"
-            )
         choice_prompt_token_ids = _normalize_token_id_sequence(
             choice.get("prompt_token_ids") or raw_output.get("prompt_token_ids") or normalized_prompt_token_ids
         )
 
+        # -- Extract per-token ids and logprobs together --------------------
+        # Both come from the same ``content[]`` array entry-by-entry, so they are
+        # inherently the same length and aligned. Reading ids from a different
+        # source (top-level token_ids) and re-encoding decoded text when it is
+        # absent drops the trailing end-of-turn token and misaligns per-token
+        # logprobs, corrupting inference KLD — so we never do that.
+        choice_logprobs = choice.get("logprobs")
+        content_entries = choice_logprobs.get("content") if isinstance(choice_logprobs, dict) else None
+        if not content_entries:
+            raise RuntimeError(
+                "Fireworks /v1/completions returned no content[] logprobs entries. "
+                "This client requires the boolean logprobs=True (content) shape to "
+                "recover exact per-token ids and sampling logprobs. Refusing to "
+                "re-encode decoded text: retokenization drops the end-of-turn token "
+                "and misaligns per-token logprobs, corrupting inference KLD. "
+                f"choice keys={list(choice.keys())}"
+            )
+
+        completion_token_ids: List[int] = []
+        completion_logprobs: List[float] = []
+        for index, entry in enumerate(content_entries):
+            if not isinstance(entry, dict) or entry.get("token_id") is None:
+                raise RuntimeError(
+                    "Fireworks /v1/completions content[] entry is missing token_id "
+                    f"at index {index}; cannot align per-token logprobs to token ids "
+                    "without re-encoding. Refusing to return corrupted data."
+                )
+            completion_token_ids.append(int(entry["token_id"]))
+            completion_logprobs.append(_extract_entry_logprob(entry))
+
         completion_text = self.decode_token_ids(token_ids=completion_token_ids)
         if not completion_text:
             completion_text = str(choice.get("text") or "")
-
-        # -- Extract logprobs -----------------------------------------------
-        completion_logprobs: List[float] = []
-        choice_logprobs = choice.get("logprobs")
-        if isinstance(choice_logprobs, dict):
-            token_logprobs = choice_logprobs.get("token_logprobs") or []
-            if token_logprobs:
-                completion_logprobs = [float(lp) if lp is not None else 0.0 for lp in token_logprobs]
-            else:
-                content_logprobs = choice_logprobs.get("content") or []
-                completion_logprobs = [
-                    float(entry.get("logprob", 0.0)) if isinstance(entry, dict) else 0.0
-                    for entry in content_logprobs
-                ]
-        elif isinstance(choice_logprobs, list):
-            completion_logprobs = [float(lp) if lp is not None else 0.0 for lp in choice_logprobs]
-
-        # Catch any residual token-id / logprob drift at the boundary rather than
-        # as a downstream KLD anomaly.
-        if completion_logprobs and len(completion_token_ids) != len(completion_logprobs):
-            raise RuntimeError(
-                "Fireworks /v1/completions returned mismatched completion token "
-                f"ids ({len(completion_token_ids)}) and logprobs "
-                f"({len(completion_logprobs)}). Per-token logprobs cannot be "
-                "aligned to token ids; refusing to return corrupted data."
-            )
 
         # -- Build message via parser or raw --------------------------------
         if self.tool_call_parser is not None:

--- a/eval_protocol/integrations/fireworks_v1_completions_client.py
+++ b/eval_protocol/integrations/fireworks_v1_completions_client.py
@@ -358,6 +358,12 @@ class FireworksV1CompletionsClient:
         }
         if not self.logprobs:
             request_payload.pop("logprobs", None)
+        # Always request the exact generated token ids so downstream RL training
+        # can align per-token logprobs to token ids position-by-position.
+        # Re-encoding decoded text drops the trailing end-of-turn/EOS token and
+        # misaligns logprobs, corrupting inference KLD. Keep overridable via
+        # request_params, but default the flag on.
+        request_payload.setdefault("return_token_ids", True)
 
         max_retries = 40
         base_delay = 10.0
@@ -396,6 +402,15 @@ class FireworksV1CompletionsClient:
         completion_token_ids = _normalize_token_id_sequence(
             choice.get("token_ids") or raw_output.get("completion_token_ids") or []
         )
+        if not completion_token_ids:
+            raise RuntimeError(
+                "Fireworks /v1/completions returned no exact completion token IDs "
+                "(choices[].token_ids and raw_output.completion_token_ids both empty) "
+                "even though return_token_ids=True was requested. "
+                "Refusing to re-encode decoded text: retokenization drops the "
+                "end-of-turn token and misaligns per-token logprobs, corrupting "
+                f"inference KLD. choice keys={list(choice.keys())}"
+            )
         choice_prompt_token_ids = _normalize_token_id_sequence(
             choice.get("prompt_token_ids") or raw_output.get("prompt_token_ids") or normalized_prompt_token_ids
         )
@@ -403,9 +418,6 @@ class FireworksV1CompletionsClient:
         completion_text = self.decode_token_ids(token_ids=completion_token_ids)
         if not completion_text:
             completion_text = str(choice.get("text") or "")
-        if not completion_token_ids and completion_text:
-            tokenizer = self._get_tokenizer()
-            completion_token_ids = list(tokenizer.encode(completion_text, add_special_tokens=False))
 
         # -- Extract logprobs -----------------------------------------------
         completion_logprobs: List[float] = []
@@ -422,6 +434,16 @@ class FireworksV1CompletionsClient:
                 ]
         elif isinstance(choice_logprobs, list):
             completion_logprobs = [float(lp) if lp is not None else 0.0 for lp in choice_logprobs]
+
+        # Catch any residual token-id / logprob drift at the boundary rather than
+        # as a downstream KLD anomaly.
+        if completion_logprobs and len(completion_token_ids) != len(completion_logprobs):
+            raise RuntimeError(
+                "Fireworks /v1/completions returned mismatched completion token "
+                f"ids ({len(completion_token_ids)}) and logprobs "
+                f"({len(completion_logprobs)}). Per-token logprobs cannot be "
+                "aligned to token ids; refusing to return corrupted data."
+            )
 
         # -- Build message via parser or raw --------------------------------
         if self.tool_call_parser is not None:

--- a/eval_protocol/integrations/fireworks_v1_completions_client.py
+++ b/eval_protocol/integrations/fireworks_v1_completions_client.py
@@ -83,19 +83,6 @@ def _normalize_token_id_sequence(values: Any) -> List[int]:
     return [int(x) for x in list(values)]
 
 
-def _extract_entry_logprob(entry: Dict[str, Any]) -> float:
-    """Return the per-token logprob from a ``content[]`` logprobs entry.
-
-    Prefer ``sampling_logprob`` (the exact, full-precision value the sampler
-    actually drew with) over ``logprob`` (a rounded/verification value). The
-    sampler value is what RL training needs for accurate inference KLD.
-    """
-    value = entry.get("sampling_logprob")
-    if value is None:
-        value = entry.get("logprob", 0.0)
-    return float(value) if value is not None else 0.0
-
-
 def _coerce_message_content_to_text(content: Any) -> str:
     if content is None:
         return ""
@@ -437,8 +424,15 @@ class FireworksV1CompletionsClient:
                     f"at index {index}; cannot align per-token logprobs to token ids "
                     "without re-encoding. Refusing to return corrupted data."
                 )
+            if entry.get("sampling_logprob") is None:
+                raise RuntimeError(
+                    "Fireworks /v1/completions content[] entry is missing "
+                    f"sampling_logprob at index {index}. The sampling logprob is the "
+                    "exact value the sampler drew with and is required for correct "
+                    "inference KLD; refusing to substitute the rounded logprob or 0.0."
+                )
             completion_token_ids.append(int(entry["token_id"]))
-            completion_logprobs.append(_extract_entry_logprob(entry))
+            completion_logprobs.append(float(entry["sampling_logprob"]))
 
         completion_text = self.decode_token_ids(token_ids=completion_token_ids)
         if not completion_text:

--- a/tests/test_fireworks_v1_completions_client.py
+++ b/tests/test_fireworks_v1_completions_client.py
@@ -152,80 +152,44 @@ def _install_fake_completion(client, monkeypatch, payload):
     return captured
 
 
-def test_request_payload_sets_return_token_ids(monkeypatch):
-    client = FireworksV1CompletionsClient(
-        model_id="test-model",
-        tokenizer_name_or_path="Qwen/Qwen3-0.6B",
-    )
-    monkeypatch.setattr(client, "decode_token_ids", lambda token_ids: "hello")
-    captured = _install_fake_completion(
-        client,
-        monkeypatch,
-        {
-            "choices": [
-                {
-                    "token_ids": [5, 6, 7],
-                    "finish_reason": "stop",
-                    "logprobs": {"token_logprobs": [-0.1, -0.2, -0.3]},
-                }
-            ],
-        },
-    )
-    result = asyncio.run(client.create_completion_from_prompt_ids(prompt_token_ids=[1, 2]))
-    assert captured["return_token_ids"] is True
-    assert "raw_output" not in captured
-    assert result["completion_ids"] == [5, 6, 7]
-    assert len(result["completion_ids"]) == len(result["completion_logprobs"])
-    asyncio.run(client.close())
-
-
-def test_request_params_can_override_flags(monkeypatch):
-    client = FireworksV1CompletionsClient(
-        model_id="test-model",
-        tokenizer_name_or_path="Qwen/Qwen3-0.6B",
-        request_params={"return_token_ids": False},
-    )
-    monkeypatch.setattr(client, "decode_token_ids", lambda token_ids: "hi")
-    captured = _install_fake_completion(
-        client,
-        monkeypatch,
-        {"choices": [{"token_ids": [9], "finish_reason": "stop"}]},
-    )
-    asyncio.run(client.create_completion_from_prompt_ids(prompt_token_ids=[1]))
-    assert captured["return_token_ids"] is False
-    asyncio.run(client.close())
-
-
-def test_uses_exact_token_ids_without_reencode(monkeypatch):
+def test_reads_ids_and_sampling_logprobs_from_content(monkeypatch):
     client = FireworksV1CompletionsClient(
         model_id="test-model",
         tokenizer_name_or_path="Qwen/Qwen3-0.6B",
     )
     monkeypatch.setattr(client, "decode_token_ids", lambda token_ids: "text")
 
-    def _fail_encode():
+    def _fail_tokenizer():
         raise AssertionError("tokenizer must not be used to re-encode completion text")
 
-    monkeypatch.setattr(client, "_get_tokenizer", lambda: _fail_encode())
-    _install_fake_completion(
+    monkeypatch.setattr(client, "_get_tokenizer", lambda: _fail_tokenizer())
+    captured = _install_fake_completion(
         client,
         monkeypatch,
         {
             "choices": [
                 {
-                    "token_ids": [10, 20, 30, 40],
                     "finish_reason": "stop",
-                    "logprobs": {"token_logprobs": [-0.1, -0.2, -0.3, -0.4]},
+                    "logprobs": {
+                        "content": [
+                            {"token_id": 271, "sampling_logprob": -0.05483185, "logprob": -0.0548313},
+                            {"token_id": 248068, "sampling_logprob": -0.0014, "logprob": -0.0014},
+                            {"token_id": 26108, "logprob": -1.0},
+                        ]
+                    },
                 }
             ],
         },
     )
-    result = asyncio.run(client.create_completion_from_prompt_ids(prompt_token_ids=[1]))
-    assert result["completion_ids"] == [10, 20, 30, 40]
+    result = asyncio.run(client.create_completion_from_prompt_ids(prompt_token_ids=[1, 2]))
+    assert "return_token_ids" not in captured
+    assert result["completion_ids"] == [271, 248068, 26108]
+    assert result["completion_logprobs"] == [-0.05483185, -0.0014, -1.0]
+    assert len(result["completion_ids"]) == len(result["completion_logprobs"])
     asyncio.run(client.close())
 
 
-def test_raises_when_no_exact_token_ids(monkeypatch):
+def test_raises_when_no_content_logprobs(monkeypatch):
     client = FireworksV1CompletionsClient(
         model_id="test-model",
         tokenizer_name_or_path="Qwen/Qwen3-0.6B",
@@ -235,12 +199,39 @@ def test_raises_when_no_exact_token_ids(monkeypatch):
         monkeypatch,
         {"choices": [{"text": "hello world", "finish_reason": "stop"}]},
     )
-    with pytest.raises(RuntimeError, match="no exact completion token IDs"):
+    with pytest.raises(RuntimeError, match="no content\\[\\] logprobs entries"):
         asyncio.run(client.create_completion_from_prompt_ids(prompt_token_ids=[1, 2]))
     asyncio.run(client.close())
 
 
-def test_raises_on_id_logprob_length_mismatch(monkeypatch):
+def test_ignores_legacy_token_logprobs_shape(monkeypatch):
+    """The legacy token_logprobs shape has no content[]; the client must not use it."""
+    client = FireworksV1CompletionsClient(
+        model_id="test-model",
+        tokenizer_name_or_path="Qwen/Qwen3-0.6B",
+    )
+    _install_fake_completion(
+        client,
+        monkeypatch,
+        {
+            "choices": [
+                {
+                    "finish_reason": "stop",
+                    "token_ids": [1, 2, 3],
+                    "logprobs": {
+                        "token_ids": [1, 2, 3],
+                        "token_logprobs": [-0.1, -0.2, -0.3],
+                    },
+                }
+            ],
+        },
+    )
+    with pytest.raises(RuntimeError, match="no content\\[\\] logprobs entries"):
+        asyncio.run(client.create_completion_from_prompt_ids(prompt_token_ids=[1]))
+    asyncio.run(client.close())
+
+
+def test_raises_when_content_entry_missing_token_id(monkeypatch):
     client = FireworksV1CompletionsClient(
         model_id="test-model",
         tokenizer_name_or_path="Qwen/Qwen3-0.6B",
@@ -252,14 +243,18 @@ def test_raises_on_id_logprob_length_mismatch(monkeypatch):
         {
             "choices": [
                 {
-                    "token_ids": [1, 2, 3],
                     "finish_reason": "stop",
-                    "logprobs": {"token_logprobs": [-0.1, -0.2, -0.3, -0.4]},
+                    "logprobs": {
+                        "content": [
+                            {"token_id": 1, "sampling_logprob": -0.1},
+                            {"sampling_logprob": -0.2},
+                        ]
+                    },
                 }
             ],
         },
     )
-    with pytest.raises(RuntimeError, match="mismatched completion token"):
+    with pytest.raises(RuntimeError, match="missing token_id"):
         asyncio.run(client.create_completion_from_prompt_ids(prompt_token_ids=[1]))
     asyncio.run(client.close())
 

--- a/tests/test_fireworks_v1_completions_client.py
+++ b/tests/test_fireworks_v1_completions_client.py
@@ -174,7 +174,7 @@ def test_reads_ids_and_sampling_logprobs_from_content(monkeypatch):
                         "content": [
                             {"token_id": 271, "sampling_logprob": -0.05483185, "logprob": -0.0548313},
                             {"token_id": 248068, "sampling_logprob": -0.0014, "logprob": -0.0014},
-                            {"token_id": 26108, "logprob": -1.0},
+                            {"token_id": 26108, "sampling_logprob": -1.0, "logprob": -0.99},
                         ]
                     },
                 }
@@ -186,6 +186,34 @@ def test_reads_ids_and_sampling_logprobs_from_content(monkeypatch):
     assert result["completion_ids"] == [271, 248068, 26108]
     assert result["completion_logprobs"] == [-0.05483185, -0.0014, -1.0]
     assert len(result["completion_ids"]) == len(result["completion_logprobs"])
+    asyncio.run(client.close())
+
+
+def test_raises_when_content_entry_missing_sampling_logprob(monkeypatch):
+    client = FireworksV1CompletionsClient(
+        model_id="test-model",
+        tokenizer_name_or_path="Qwen/Qwen3-0.6B",
+    )
+    monkeypatch.setattr(client, "decode_token_ids", lambda token_ids: "text")
+    _install_fake_completion(
+        client,
+        monkeypatch,
+        {
+            "choices": [
+                {
+                    "finish_reason": "stop",
+                    "logprobs": {
+                        "content": [
+                            {"token_id": 1, "sampling_logprob": -0.1},
+                            {"token_id": 2, "logprob": -0.2},
+                        ]
+                    },
+                }
+            ],
+        },
+    )
+    with pytest.raises(RuntimeError, match="missing .*sampling_logprob"):
+        asyncio.run(client.create_completion_from_prompt_ids(prompt_token_ids=[1]))
     asyncio.run(client.close())
 
 

--- a/tests/test_fireworks_v1_completions_client.py
+++ b/tests/test_fireworks_v1_completions_client.py
@@ -124,6 +124,146 @@ def test_build_prompt_token_ids_handles_dict_input_ids(monkeypatch):
     asyncio.run(client.close())
 
 
+class _FakeResponse:
+    def __init__(self, payload: Dict[str, Any]):
+        self._payload = payload
+
+    def model_dump(self) -> Dict[str, Any]:
+        return self._payload
+
+
+def _install_fake_completion(client, monkeypatch, payload):
+    captured: Dict[str, Any] = {}
+
+    async def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _FakeResponse(payload)
+
+    class _FakeCompletions:
+        create = staticmethod(fake_create)
+
+    class _FakeClient:
+        completions = _FakeCompletions()
+
+        async def close(self):
+            return None
+
+    monkeypatch.setattr(client, "_client", _FakeClient())
+    return captured
+
+
+def test_request_payload_sets_return_token_ids(monkeypatch):
+    client = FireworksV1CompletionsClient(
+        model_id="test-model",
+        tokenizer_name_or_path="Qwen/Qwen3-0.6B",
+    )
+    monkeypatch.setattr(client, "decode_token_ids", lambda token_ids: "hello")
+    captured = _install_fake_completion(
+        client,
+        monkeypatch,
+        {
+            "choices": [
+                {
+                    "token_ids": [5, 6, 7],
+                    "finish_reason": "stop",
+                    "logprobs": {"token_logprobs": [-0.1, -0.2, -0.3]},
+                }
+            ],
+        },
+    )
+    result = asyncio.run(client.create_completion_from_prompt_ids(prompt_token_ids=[1, 2]))
+    assert captured["return_token_ids"] is True
+    assert "raw_output" not in captured
+    assert result["completion_ids"] == [5, 6, 7]
+    assert len(result["completion_ids"]) == len(result["completion_logprobs"])
+    asyncio.run(client.close())
+
+
+def test_request_params_can_override_flags(monkeypatch):
+    client = FireworksV1CompletionsClient(
+        model_id="test-model",
+        tokenizer_name_or_path="Qwen/Qwen3-0.6B",
+        request_params={"return_token_ids": False},
+    )
+    monkeypatch.setattr(client, "decode_token_ids", lambda token_ids: "hi")
+    captured = _install_fake_completion(
+        client,
+        monkeypatch,
+        {"choices": [{"token_ids": [9], "finish_reason": "stop"}]},
+    )
+    asyncio.run(client.create_completion_from_prompt_ids(prompt_token_ids=[1]))
+    assert captured["return_token_ids"] is False
+    asyncio.run(client.close())
+
+
+def test_uses_exact_token_ids_without_reencode(monkeypatch):
+    client = FireworksV1CompletionsClient(
+        model_id="test-model",
+        tokenizer_name_or_path="Qwen/Qwen3-0.6B",
+    )
+    monkeypatch.setattr(client, "decode_token_ids", lambda token_ids: "text")
+
+    def _fail_encode():
+        raise AssertionError("tokenizer must not be used to re-encode completion text")
+
+    monkeypatch.setattr(client, "_get_tokenizer", lambda: _fail_encode())
+    _install_fake_completion(
+        client,
+        monkeypatch,
+        {
+            "choices": [
+                {
+                    "token_ids": [10, 20, 30, 40],
+                    "finish_reason": "stop",
+                    "logprobs": {"token_logprobs": [-0.1, -0.2, -0.3, -0.4]},
+                }
+            ],
+        },
+    )
+    result = asyncio.run(client.create_completion_from_prompt_ids(prompt_token_ids=[1]))
+    assert result["completion_ids"] == [10, 20, 30, 40]
+    asyncio.run(client.close())
+
+
+def test_raises_when_no_exact_token_ids(monkeypatch):
+    client = FireworksV1CompletionsClient(
+        model_id="test-model",
+        tokenizer_name_or_path="Qwen/Qwen3-0.6B",
+    )
+    _install_fake_completion(
+        client,
+        monkeypatch,
+        {"choices": [{"text": "hello world", "finish_reason": "stop"}]},
+    )
+    with pytest.raises(RuntimeError, match="no exact completion token IDs"):
+        asyncio.run(client.create_completion_from_prompt_ids(prompt_token_ids=[1, 2]))
+    asyncio.run(client.close())
+
+
+def test_raises_on_id_logprob_length_mismatch(monkeypatch):
+    client = FireworksV1CompletionsClient(
+        model_id="test-model",
+        tokenizer_name_or_path="Qwen/Qwen3-0.6B",
+    )
+    monkeypatch.setattr(client, "decode_token_ids", lambda token_ids: "text")
+    _install_fake_completion(
+        client,
+        monkeypatch,
+        {
+            "choices": [
+                {
+                    "token_ids": [1, 2, 3],
+                    "finish_reason": "stop",
+                    "logprobs": {"token_logprobs": [-0.1, -0.2, -0.3, -0.4]},
+                }
+            ],
+        },
+    )
+    with pytest.raises(RuntimeError, match="mismatched completion token"):
+        asyncio.run(client.create_completion_from_prompt_ids(prompt_token_ids=[1]))
+    asyncio.run(client.close())
+
+
 def test_thinking_kwargs_respects_enable_thinking():
     client_none = FireworksV1CompletionsClient(
         model_id="test", tokenizer_name_or_path="Qwen/Qwen3-0.6B",

--- a/tests/test_fireworks_v1_completions_client.py
+++ b/tests/test_fireworks_v1_completions_client.py
@@ -184,7 +184,7 @@ def test_reads_ids_and_sampling_logprobs_from_content(monkeypatch):
     result = asyncio.run(client.create_completion_from_prompt_ids(prompt_token_ids=[1, 2]))
     assert "return_token_ids" not in captured
     assert result["completion_ids"] == [271, 248068, 26108]
-    assert result["completion_logprobs"] == [-0.05483185, -0.0014, -1.0]
+    assert result["completion_logprobs"] == pytest.approx([-0.05483185, -0.0014, -1.0])
     assert len(result["completion_ids"]) == len(result["completion_logprobs"])
     asyncio.run(client.close())
 


### PR DESCRIPTION
## Summary

`FireworksV1CompletionsClient.create_completion_from_prompt_ids` is the sampling path for RL rollouts against Fireworks `/v1/completions`. Downstream, the trainer aligns each per-token inference logprob to its completion token id position-by-position, so `completion_ids[i]` and the per-token logprob at `i` must be the same length and the same tokens.

**This client always requests boolean `logprobs=True`, so every response uses the new `content[]` logprobs shape** (`choices[0].logprobs.content[]`, where each entry carries `token_id`, `token`, `bytes`, `logprob`, and `sampling_logprob`). The legacy integer `logprobs=1` shape (`token_logprobs` + `logprobs.token_ids`) is not requested and is intentionally not supported here. This PR makes the client read everything from that new-mode `content[]` array.

## Bug 1 — alignment / KLD corruption (the actual bug)

Per-token ids and logprobs were read from two **independent** places:

- **ids**: only from the top-level `choices[].token_ids`, which is populated **only when `return_token_ids=True`** — a flag this client never sent. When absent, ids were silently re-derived via `tokenizer.encode(decode(text), add_special_tokens=False)`.
- **logprobs**: from `content[].logprob`, always full length.

Retokenization does not reproduce the model's exact sequence — the trailing end-of-turn/EOS token decodes to empty text and is not re-added — so `completion_ids = N` while logprobs = `N+1`. The +1 shift misaligns every per-token logprob against the wrong token, and per-token KLD becomes garbage.

Observed on a GLM-family LoRA RFT deployment (MTP speculative decoding): `completion_ids` was one shorter than the logprobs on all 120 rows (diff=+1) and `inference_kld` climbed to ~60; aligning ids correctly made diff=0 and `inference_kld` flat ~0.028.

**Fix:** the `content[]` array already carries `token_id` per entry, so we read ids and logprobs from the **same array, entry-by-entry**. They are the same length and aligned by construction — no `return_token_ids`, no re-encode fallback.

## Bug 2 — sampling precision (more of a feature)

In the `content[]` shape each entry exposes two numbers: `sampling_logprob` (the exact, full-precision value the sampler actually drew with) and `logprob` (a rounded/verification value). The client read the rounded `logprob`. We now read `sampling_logprob` (the correct inference-side value for KLD) and fail loud if it is missing.

## Changes

- Read per-token `completion_ids` from `content[].token_id` and logprobs from `content[].sampling_logprob` in a single pass, so they are aligned by construction.
- Drop the `tokenizer.encode(...)` re-encode fallback and the legacy id/logprob sources (`token_logprobs`, top-level `token_ids`, `raw_output.completion_token_ids`).
- No longer send `return_token_ids`; rely on the `content[]` shape that boolean `logprobs=True` already returns.
- Fail loud when `content[]` is absent (e.g. logprobs disabled or legacy shape returned) or when a `content[]` entry lacks `token_id` or `sampling_logprob`, instead of silently returning corrupted data.

Mirrors the intent of the upstream Fireworks monorepo fix (fw-ai/fireworks#33729): callers that use the base `eval_protocol` client unmodified (e.g. `examples/multihop_qa/multihop_qa_rollout.py`) are no longer silently corrupted.

## Test plan

- [x] Unit: `content[]` with `token_id` + `sampling_logprob` -> `completion_ids` from `token_id`, logprobs from `sampling_logprob`, lengths equal, tokenizer never used to re-encode.
- [x] Unit: no `content[]` -> raises (no silent re-encode).
- [x] Unit: legacy `token_logprobs` shape (no `content[]`) -> raises (legacy not supported).
- [x] Unit: `content[]` entry missing `token_id` -> raises.
- [x] Unit: `content[]` entry missing `sampling_logprob` -> raises.
- [x] `pytest tests/test_fireworks_v1_completions_client.py` passes (13 tests).

---

Supersedes #457 (same commits, moved from a fork branch to an in-repo branch so CI runs with secrets). Previously approved by @websterbei.

Made with [Cursor](https://cursor.com)